### PR TITLE
Small fix for scripts running twice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,13 @@ import React, { useEffect, useRef } from 'react'
 function DangerouslySetHtmlContent({ html, dangerouslySetInnerHTML, ...rest }) {
   // We remove 'dangerouslySetInnerHTML' from props passed to the div
   const divRef = useRef(null)
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
     if (!html || !divRef.current) throw new Error("html prop cant't be null")
-
+    if (!isFirstRender.current) return;
+    isFirstRender.current = false;
+    
     const slotHtml = document.createRange().createContextualFragment(html) // Create a 'tiny' document and parse the html string
     divRef.current.innerHTML = '' // Clear the container
     divRef.current.appendChild(slotHtml) // Append the new content


### PR DESCRIPTION
I noticed that the useEffect that sets the `div`'s inner HTML was running twice. This is fine for the content being rendered, since the innerHTML is cleared. but the script tags run twice, causing some issues in our use-case. 

This is a very simple hack to stop that from happening.