### PR TITLE
Widen React peer dependency to >=18.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:watch": "react-scripts test --env=jsdom"
   },
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": ">=18.2.0"
   },
   "devDependencies": {
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
Relax the React peer dependency range from ^18.2.0 to >=18.2.0 to allow projects using newer React versions while keeping 18.2.0+ support.

Fixes: https://github.com/christo-pr/dangerously-set-html-content/issues/15